### PR TITLE
Add C++14 programming language

### DIFF
--- a/cms/grading/languages/cpp14_gpp.py
+++ b/cms/grading/languages/cpp14_gpp.py
@@ -2,6 +2,7 @@
 
 # Contest Management System - http://cms-dev.github.io/
 # Copyright © 2016 Stefano Maggiolo <s.maggiolo@gmail.com>
+# Copyright © 2019 Andrey Vihrov <andrey.vihrov@gmail.com>
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as
@@ -16,24 +17,24 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-"""C++11 programming language definition."""
+"""C++14 programming language definition."""
 
 from cms.grading import CompiledLanguage
 
 
-__all__ = ["Cpp11Gpp"]
+__all__ = ["Cpp14Gpp"]
 
 
-class Cpp11Gpp(CompiledLanguage):
+class Cpp14Gpp(CompiledLanguage):
     """This defines the C++ programming language, compiled with g++ (the
-    version available on the system) using the C++11 standard.
+    version available on the system) using the C++14 standard.
 
     """
 
     @property
     def name(self):
         """See Language.name."""
-        return "C++11 / g++"
+        return "C++14 / g++"
 
     @property
     def source_extensions(self):
@@ -42,12 +43,12 @@ class Cpp11Gpp(CompiledLanguage):
 
     @property
     def header_extensions(self):
-        """See Language.source_extensions."""
+        """See Language.header_extensions."""
         return [".h"]
 
     @property
     def object_extensions(self):
-        """See Language.source_extensions."""
+        """See Language.object_extensions."""
         return [".o"]
 
     def get_compilation_commands(self,
@@ -57,7 +58,7 @@ class Cpp11Gpp(CompiledLanguage):
         command = ["/usr/bin/g++"]
         if for_evaluation:
             command += ["-DEVAL"]
-        command += ["-std=gnu++11", "-O2", "-pipe", "-static",
+        command += ["-std=gnu++14", "-O2", "-pipe", "-static",
                     "-s", "-o", executable_filename]
         command += source_filenames
         return [command]

--- a/cmstestsuite/Tests.py
+++ b/cmstestsuite/Tests.py
@@ -40,6 +40,7 @@ from cmstestsuite.Test import Test, CheckOverallScore, CheckCompilationFail, \
 
 
 LANG_CPP = "C++11 / g++"
+LANG_CPP14 = "C++14 / g++" # TODO: Enable C++14 tests with GCC 5+
 LANG_C = "C11 / gcc"
 LANG_HS = "Haskell / ghc"
 LANG_JAVA = "Java / JDK"
@@ -408,5 +409,13 @@ ALL_TESTS = [
          task=batch_fileio, filenames=['write-big-fileio.%l'],
          languages=(LANG_C,),
          checks=[CheckOverallScore(0, 100)]),
+
+    # Language-specific tests
+
+    # TODO: Enable C++14 tests with GCC 5+
+    #Test('correct-stdio-cxx14',
+    #     task=batch_stdio, filenames=['correct-stdio-cxx14.%l'],
+    #     languages=(LANG_CPP14,),
+    #     checks=[CheckOverallScore(100, 100)]),
 
 ]

--- a/cmstestsuite/code/correct-stdio-cxx14.cpp
+++ b/cmstestsuite/code/correct-stdio-cxx14.cpp
@@ -1,0 +1,11 @@
+#include <iostream>
+#include <memory>
+
+// Test C++14 support
+
+int main() {
+    auto ptr = std::make_unique<int>();
+    std::cin >> *ptr;
+    std::cout << "correct " << *ptr << std::endl;
+    return 0b0'0'0;
+}

--- a/setup.py
+++ b/setup.py
@@ -183,6 +183,7 @@ setup(
         ],
         "cms.grading.languages": [
             "C++11 / g++=cms.grading.languages.cpp11_gpp:Cpp11Gpp",
+            "C++14 / g++=cms.grading.languages.cpp14_gpp:Cpp14Gpp",
             "C11 / gcc=cms.grading.languages.c11_gcc:C11Gcc",
             "C# / Mono=cms.grading.languages.csharp_mono:CSharpMono",
             "Haskell / ghc=cms.grading.languages.haskell_ghc:HaskellGhc",


### PR DESCRIPTION
Tests are disabled for now as the current CI Ubuntu version
doesn't have GCC 5 or later.